### PR TITLE
Prevent deleting node's property 'class' in Button constructor

### DIFF
--- a/src/button.js
+++ b/src/button.js
@@ -2,16 +2,16 @@ class Button {
     constructor(node, options){
         this.node = node;
         this.node.innerText = options.text;
-        this.node.className = 'button';
+        this.node.classList.add('button');
         this.onClick = options.onClick;
         this.node.addEventListener('click', this.onClick);
     }
 
     option(options){
-        if (options.hasOwnProperty('text')){
+        if (options.hasOwnProperty('text')) {
             this.node.innerText = options.text;
         }
-        if (options.hasOwnProperty('onClick')){
+        if (options.hasOwnProperty('onClick')) {
             this.node.removeEventListener('click', this.onClick);
             this.onClick = options.onClick;
             this.node.addEventListener('click', this.onClick);

--- a/test/button.test.js
+++ b/test/button.test.js
@@ -1,46 +1,53 @@
 const Button = require('../src/button.js').Button;     
 
 test('Сhange node text', () => {
-    const testNode = document.createElement('div');
+    const buttonNode = document.createElement('div');
     const text = 'test_text';
-    const testObj = new Button(testNode, {text: text});
-    expect(testNode.innerText).toBe(text);
+    const testObj = new Button(buttonNode, {text: text});
+    expect(buttonNode.innerText).toBe(text);
 });
 
 test('Add class button', () => {
-    const testNode = document.createElement('div');
+    const buttonNode = document.createElement('div');
     const className = 'button';
-    const testObj = new Button(testNode, {text: ''});
-    expect(testNode.className).toBe(className);
+    const testObj = new Button(buttonNode, {text: ''});
+    expect(buttonNode.className).toBe(className);
 });
 
 test('Add eventHandler', () => {
-    const testNode = document.createElement('div');
+    const buttonNode = document.createElement('div');
     let handlerIsCalled;
     const clickHandler = function() {
         handlerIsCalled = true;
     };
-    const testObj = new Button(testNode, {text: '', onClick: clickHandler});
-    testNode.dispatchEvent(new Event('click'));
+    const testObj = new Button(buttonNode, {text: '', onClick: clickHandler});
+    buttonNode.dispatchEvent(new Event('click'));
     expect(handlerIsCalled).toBe(true);
 });
 
 test('Change text option', () => {
-    const testNode = document.createElement('div');
+    const buttonNode = document.createElement('div');
     const text = 'test_text';
-    const testObj = new Button(testNode, {});
+    const testObj = new Button(buttonNode, {});
     testObj.option({text: text});
-    expect(testNode.innerText).toBe(text);
+    expect(buttonNode.innerText).toBe(text);
 });
 
 test('Change onClick option', () => {
-    const testNode = document.createElement('div');
+    const buttonNode = document.createElement('div');
     let handlerIsCalled = false;
     const clickHandler = function() {
         handlerIsCalled = true;
     };
-    const testObj = new Button(testNode, {});
+    const testObj = new Button(buttonNode, {});
     testObj.option({onClick: clickHandler});
-    testNode.dispatchEvent(new Event('click'));
+    buttonNode.dispatchEvent(new Event('click'));
     expect(handlerIsCalled).toBe(true);
+});
+
+test('Add class selector at node', () => {
+    const buttonNode = document.createElement('div');
+    buttonNode.className = 'element';
+    const buttonObject = new Button(buttonNode, {});
+    expect(buttonNode.className).toBe('element button');
 });

--- a/test/button.test.js
+++ b/test/button.test.js
@@ -9,9 +9,8 @@ test('Сhange node text', () => {
 
 test('Add class button', () => {
     const buttonNode = document.createElement('div');
-    const className = 'button';
     const testObj = new Button(buttonNode, {text: ''});
-    expect(buttonNode.className).toBe(className);
+    expect(buttonNode.classList.contains('button')).toBe(true);
 });
 
 test('Add eventHandler', () => {
@@ -49,5 +48,5 @@ test('Add class selector at node', () => {
     const buttonNode = document.createElement('div');
     buttonNode.className = 'element';
     const buttonObject = new Button(buttonNode, {});
-    expect(buttonNode.className).toBe('element button');
+    expect(buttonNode.classList.contains('element')).toBe(true);
 });

--- a/test/button.test.js
+++ b/test/button.test.js
@@ -1,30 +1,30 @@
 const Button = require('../src/button.js').Button;     
 
-test('Сhange node text', () => {
+test('Button correctly displays "text" option', () => {
     const buttonNode = document.createElement('div');
     const text = 'test_text';
-    const testObj = new Button(buttonNode, {text: text});
+    new Button(buttonNode, {text: text});
     expect(buttonNode.innerText).toBe(text);
 });
 
-test('Add class button', () => {
+test('Button adds class "button" to an element', () => {
     const buttonNode = document.createElement('div');
-    const testObj = new Button(buttonNode, {text: ''});
+    new Button(buttonNode, {text: ''});
     expect(buttonNode.classList.contains('button')).toBe(true);
 });
 
-test('Add eventHandler', () => {
+test('onClick handler is called after element clicked', () => {
     const buttonNode = document.createElement('div');
     let handlerIsCalled;
     const clickHandler = function() {
         handlerIsCalled = true;
     };
-    const testObj = new Button(buttonNode, {text: '', onClick: clickHandler});
+    new Button(buttonNode, {text: '', onClick: clickHandler});
     buttonNode.dispatchEvent(new Event('click'));
     expect(handlerIsCalled).toBe(true);
 });
 
-test('Change text option', () => {
+test('Button.option method correctly applies new "text" option', () => {
     const buttonNode = document.createElement('div');
     const text = 'test_text';
     const testObj = new Button(buttonNode, {});
@@ -32,9 +32,9 @@ test('Change text option', () => {
     expect(buttonNode.innerText).toBe(text);
 });
 
-test('Change onClick option', () => {
+test('Button.option method correctly changes "onClick" option', () => {
     const buttonNode = document.createElement('div');
-    let handlerIsCalled = false;
+    let handlerIsCalled;
     const clickHandler = function() {
         handlerIsCalled = true;
     };
@@ -44,9 +44,9 @@ test('Change onClick option', () => {
     expect(handlerIsCalled).toBe(true);
 });
 
-test('Add class selector at node', () => {
+test('Button does not delete initial element CSS classes', () => {
     const buttonNode = document.createElement('div');
     buttonNode.className = 'element';
-    const buttonObject = new Button(buttonNode, {});
+    new Button(buttonNode, {});
     expect(buttonNode.classList.contains('element')).toBe(true);
 });


### PR DESCRIPTION
Change Button constructor to append new class 'button' to node `classList`.
```
el.className = 'my-class';
new Button(el, {});
// el.classList should contain 'my-class'
```